### PR TITLE
Add PEAN.JS to Web development frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Your pull requests are very welcome! Let's make this the awesomest resource for 
 * [Koa](http://koajs.com/) - A framework which aims to be a smaller, more expressive, and more robust foundation for web applications.
 * [LoopBack](http://loopback.io/) - Powerful Node.js framework for creating APIs and easily connecting to backend data sources.
 * [Meteor](https://www.meteor.com/) - A platform that has strong features such as live page update, sync and hopt code pushes.
+* [PEAN.JS](https://github.com/StetSolutions/pean) - Full-Stack JavaScript Using PostgreSQL, Express, AngularJS, and Node.js.
 * [Restify](http://mcavage.me/node-restify/) - A node framework built specifically to enable you to build correct REST web services.
 * [SailsJS](http://sailsjs.org) - An MVC web framework with a modern twist, supporting WebSockets, streams, and a data-driven API.
 * [Totaljs](http://www.totaljs.com/) - Friendly responsive design web application framework for node.


### PR DESCRIPTION
https://github.com/StetSolutions/pean

Rather than having a NoSQL database like MongoDB, this project takes the MEAN.JS framework
and uses PostgreSQL and Sequelize instead of MongoDB and Mongoose. Great if you are working
with a relational database.